### PR TITLE
Fix "pyenv init - no longer sets PATH." message

### DIFF
--- a/Makefile.venv
+++ b/Makefile.venv
@@ -129,7 +129,8 @@ $(VENV):
 	@echo "Creating virtual env, python version is: ${PYTHON_VERSION}"
 	$(PYENV) install --skip-existing ${PYTHON_VERSION}
 
-	@eval "$$(pyenv init --path); $$(pyenv init -)"; \
+	@eval "$$(pyenv init --path)"; \
+	@eval "$$(pyenv init -)"; \
 	$(PYENV) local ${PYTHON_VERSION}; \
 	$(PY) -m venv --prompt ${VENV_PROMT} ${VENVDIR}
 

--- a/Makefile.venv
+++ b/Makefile.venv
@@ -60,10 +60,10 @@ else
 	PYENV = pyenv
 endif
 
-ifeq ($(OS),Linux)
-	export PYENV_ROOT=${HOME}/.pyenv
-	export PATH:=${PYENV_ROOT}/bin:${PATH}
-endif
+# Add pyenv executable to PATH and enable shims
+export PYENV_ROOT=${HOME}/.pyenv
+export PATH:=${PYENV_ROOT}/bin:${PATH}
+
 
 prerequisites: $(OS)
 
@@ -129,6 +129,7 @@ $(VENV):
 	@echo "Creating virtual env, python version is: ${PYTHON_VERSION}"
 	$(PYENV) install --skip-existing ${PYTHON_VERSION}
 
+	@eval "$$(pyenv init --path)"; \
 	@eval "$$(pyenv init -)"; \
 	$(PYENV) local ${PYTHON_VERSION}; \
 	$(PY) -m venv --prompt ${VENV_PROMT} ${VENVDIR}

--- a/Makefile.venv
+++ b/Makefile.venv
@@ -130,7 +130,7 @@ $(VENV):
 	$(PYENV) install --skip-existing ${PYTHON_VERSION}
 
 	@eval "$$(pyenv init --path)"; \
-	@eval "$$(pyenv init -)"; \
+	eval "$$(pyenv init -)"; \
 	$(PYENV) local ${PYTHON_VERSION}; \
 	$(PY) -m venv --prompt ${VENV_PROMT} ${VENVDIR}
 

--- a/Makefile.venv
+++ b/Makefile.venv
@@ -129,8 +129,7 @@ $(VENV):
 	@echo "Creating virtual env, python version is: ${PYTHON_VERSION}"
 	$(PYENV) install --skip-existing ${PYTHON_VERSION}
 
-	@eval "$$(pyenv init --path)"; \
-	@eval "$$(pyenv init -)"; \
+	@eval "$$(pyenv init --path); $$(pyenv init -)"; \
 	$(PYENV) local ${PYTHON_VERSION}; \
 	$(PY) -m venv --prompt ${VENV_PROMT} ${VENVDIR}
 


### PR DESCRIPTION
A recent change in pyenv (https://github.com/pyenv/pyenv/issues/1906) lead to CI failures.